### PR TITLE
Add v0.5 data scaffold and CI improvements

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+*.zip filter=lfs diff=lfs merge=lfs -text
+*.mid filter=lfs diff=lfs merge=lfs -text
+*.midi filter=lfs diff=lfs merge=lfs -text
+*.png filter=lfs diff=lfs merge=lfs -text
+*.svg filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ dist/
 *.ipynb
 
 # Large binary assets
+*.zip
+*.png
 *.mid
 *.midi
 *.svg

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 TylerHK
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,18 +1,19 @@
 # LuminaNotes
 
-LuminaNotes is a workspace for experiments around generative music and creative coding.
-It aggregates project notes alongside Python modules used for data processing and
-model experimentation.
+LuminaNotes explores techniques for generative music and creative coding. It collects research notes alongside Python modules used for data preparation, model training and evaluation.
+
+This repository aims to provide:
+
+- Examples of data loaders and utilities for music datasets.
+- Prototype transformer models under the `omniintent` package.
+- Test suites to ensure reproducible experiments.
+
+Large media assets are stored using Git LFS to keep the repository lightweight.
 
 ## Directory Structure
 
 - `Lumina/` – Existing notes and documentation.
-- `src/` – Python source modules.
-  - `echoes/` – Utilities for loading and validating Morphology Map JSON files.
-  - `omniintent/` – Placeholder for transformer-based model code.
-- `tests/` – Pytest suites and related test assets.
-- `data/` – Location for large bundles such as Echoes or Creative Packs.
+- `src/` – Python source modules for Echoes and OmniIntent projects.
+- `tests/` – Pytest suites and tokenizer specs.
+- `data/` – Bundled data packages stored via Git LFS.
 - `.github/workflows/` – Continuous integration configuration.
-
-Large binary assets are not stored in the repository. See `data/README.md`
-for guidance on using Git LFS for large files.

--- a/data/creative_pack_v0.1/README.md
+++ b/data/creative_pack_v0.1/README.md
@@ -1,0 +1,1 @@
+This directory stores creative_pack_v0.1 data.

--- a/data/echoes_v0.5/README.md
+++ b/data/echoes_v0.5/README.md
@@ -1,0 +1,1 @@
+This directory stores echoes_v0.5 data.

--- a/data/omniintent_unit_test/README.md
+++ b/data/omniintent_unit_test/README.md
@@ -1,0 +1,1 @@
+This directory stores omniintent_unit_test data.

--- a/data/physarum/README.md
+++ b/data/physarum/README.md
@@ -1,0 +1,1 @@
+This directory stores physarum data.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ jsonschema
 pytest
 torch
 transformers
+numpy

--- a/src/omniintent/synthetic_data_generator.py
+++ b/src/omniintent/synthetic_data_generator.py
@@ -1,0 +1,11 @@
+"""Utility for generating synthetic training data for OmniIntent models."""
+
+import random
+
+
+def generate_examples(num:int=1):
+    """Return a list of simple synthetic text strings."""
+    examples = []
+    for _ in range(num):
+        examples.append(f"sample-{random.randint(0, 9999)}")
+    return examples

--- a/src/omniintent/tokenizer_spec.json
+++ b/src/omniintent/tokenizer_spec.json
@@ -1,0 +1,5 @@
+{
+  "tokenizer": "simple",
+  "vocab_size": 256,
+  "special_tokens": {"pad_token": "<PAD>"}
+}

--- a/tests/test_spec_schema.py
+++ b/tests/test_spec_schema.py
@@ -1,0 +1,10 @@
+import json
+import os
+
+
+def test_spec_schema_keys():
+    path = os.path.join(os.path.dirname(__file__), 'tokenizer_spec.json')
+    with open(path, 'r', encoding='utf-8') as f:
+        spec = json.load(f)
+    required = {'tokenizer', 'vocab_size', 'special_tokens'}
+    assert required.issubset(spec.keys())


### PR DESCRIPTION
## Summary
- initialize Git LFS for zip/mid/png/svg assets
- add data directories with README placeholders
- copy tokenizer spec and add synthetic data generator utility
- update README with project overview
- add requirements and MIT license
- ignore common Python/Jupyter/binary files
- add tests for tokenizer spec

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f1c7ccc20832dac508bd2ca13d740