### PR TITLE
Add Echoes v0.6 scaffolding and CI enhancements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,20 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
+          pip install black isort
+      - name: Preview notice
+        if: startsWith(github.ref_name, 'feature/')
+        run: echo "::notice title=Preview::You are building a feature branch"
       - name: Validate JSON files
         run: |
           python - <<'PY'
@@ -27,5 +38,9 @@ for path in pathlib.Path('.').rglob('*.json'):
     jsonschema.validate(data, {})
 print('All JSON files are valid')
 PY
+      - name: Check formatting
+        run: |
+          black --check src tests
+          isort --check src tests
       - name: Run tests
         run: pytest -v

--- a/README.md
+++ b/README.md
@@ -17,3 +17,8 @@ Large media assets are stored using Git LFS to keep the repository lightweight.
 - `tests/` – Pytest suites and tokenizer specs.
 - `data/` – Bundled data packages stored via Git LFS.
 - `.github/workflows/` – Continuous integration configuration.
+
+## Roadmap
+- Sprint-05 - 15 new capsules & Morphology v0.6.
+- Sprint-06 - Creative Pack v0.2 with micro-fiction chapter 1.
+- Sprint-07 - OmniIntent real-sensor integration.

--- a/data/echoes_v0.6/PLACEHOLDERS.txt
+++ b/data/echoes_v0.6/PLACEHOLDERS.txt
@@ -1,0 +1,3 @@
+This folder will hold fifteen new Echoes capsules along with their JSON, CSV,
+and SVG exports after Sprint-05. The contents are placeholders until that
+release.

--- a/src/echoes/capsule_template.md
+++ b/src/echoes/capsule_template.md
@@ -1,0 +1,11 @@
+---
+id: XX
+cluster: 
+payoff_scale:
+---
+
+This capsule blueprint is reserved for the upcoming Echoes release. It serves as a placeholder to ensure structural consistency across the Morphology system. When the actual capsule data arrives, this file will transform into a fully detailed description of the audio textures, transitions, and dynamic parameters.
+
+Developers may use this template to experiment with formatting or link tasks ahead of time. While the words here do not reference any real sonic element, they mimic the tone and pacing expected in the final documentation. Each sentence is intentionally kept short and direct for ease of reading.
+
+After Sprint-05, we will replace every line with an expressive explanation of frequency modulation, modulation indices, and rhythmic layering. Until then, treat these paragraphs as filler text with no interpretive meaning. They exist solely to maintain repository layout and to test automation hooks. Please remove them as soon as genuine content is ready. For reference.

--- a/src/echoes/loader.py
+++ b/src/echoes/loader.py
@@ -1,5 +1,6 @@
 import json
-from jsonschema import validate, ValidationError
+
+from jsonschema import ValidationError, validate
 
 # Placeholder schema for morphology maps
 MORPHOLOGY_SCHEMA = {
@@ -11,9 +12,10 @@ MORPHOLOGY_SCHEMA = {
     "required": ["version", "nodes"],
 }
 
+
 def load_morphology_map(path):
     """Load a morphology map from ``path`` and validate it."""
-    with open(path, 'r', encoding='utf-8') as f:
+    with open(path, "r", encoding="utf-8") as f:
         data = json.load(f)
     validate_morphology_map(data)
     return data
@@ -25,4 +27,3 @@ def validate_morphology_map(data):
         validate(instance=data, schema=MORPHOLOGY_SCHEMA)
     except ValidationError as e:
         raise
-

--- a/src/omniintent/multimodal_transformer.py
+++ b/src/omniintent/multimodal_transformer.py
@@ -1,5 +1,6 @@
 """Placeholder transformer implementation."""
 
+
 class MultimodalTransformer:
     """A stub multimodal transformer model."""
 

--- a/src/omniintent/synthetic_data_generator.py
+++ b/src/omniintent/synthetic_data_generator.py
@@ -3,7 +3,7 @@
 import random
 
 
-def generate_examples(num:int=1):
+def generate_examples(num: int = 1):
     """Return a list of simple synthetic text strings."""
     examples = []
     for _ in range(num):

--- a/tests/test_spec_schema.py
+++ b/tests/test_spec_schema.py
@@ -3,8 +3,8 @@ import os
 
 
 def test_spec_schema_keys():
-    path = os.path.join(os.path.dirname(__file__), 'tokenizer_spec.json')
-    with open(path, 'r', encoding='utf-8') as f:
+    path = os.path.join(os.path.dirname(__file__), "tokenizer_spec.json")
+    with open(path, "r", encoding="utf-8") as f:
         spec = json.load(f)
-    required = {'tokenizer', 'vocab_size', 'special_tokens'}
+    required = {"tokenizer", "vocab_size", "special_tokens"}
     assert required.issubset(spec.keys())


### PR DESCRIPTION
## Summary
- scaffold upcoming Echoes v0.6 data and capsule template
- enforce formatting and caching in CI
- document planned sprints in README
- auto-format Python files to satisfy CI

## Testing
- `black --check src tests`
- `isort --check src tests`
- `pytest -v`


------
https://chatgpt.com/codex/tasks/task_e_684f2ee94e1c832d8f526f1643d79df3