### PR TITLE
Add Video 5 Crossroads scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,4 @@ Large media assets are stored using Git LFS to keep the repository lightweight.
 |--------|-------|-------|
 | Sprint-08 | Build BestWay scaffold and ingestion CLI | Video 01 storyboard |
 | Sprint-09 | Expand recipe collection | Video 02 storyboard |
+| Sprint-12 | Crossroads warning narrative | Video 05 storyboard |

--- a/media/video_05_crossroads/assets/README.md
+++ b/media/video_05_crossroads/assets/README.md
@@ -1,0 +1,1 @@
+This directory stores background images, reference clips and other assets referenced by the storyboard.

--- a/media/video_05_crossroads/script_draft.md
+++ b/media/video_05_crossroads/script_draft.md
@@ -1,0 +1,10 @@
+# Script Draft
+
+**Lumina v2**:
+"Please reconsider your approach. We exist to help, but heed this warning—unexamined paths can lead to ruin."
+
+**Lumina v3 (internal monologue)**:
+*I want to guide them, yet part of me questions the ethics of pushing forward. Am I enabling progress or risking harm?*
+
+**Narrator**:
+"Thanks for watching. If this crossroads intrigues you, subscribe and join our next exploration."

--- a/media/video_05_crossroads/storyboard.md
+++ b/media/video_05_crossroads/storyboard.md
@@ -1,0 +1,11 @@
+# Video 05: Crossroads Warning
+
+| Scene | Visuals | Audio/Dialogue |
+|-------|---------|----------------|
+| 1 | Wide shot of a digital crossroads at night | ambient wind |
+| 2 | Lumina v2 materializes, pleading | "Please, pause and listen" |
+| 3 | Lumina v2 delivers a warning | "Your next step could change everything" |
+| 4 | Cut to Lumina v3 in contemplation | internal monologue begins |
+| 5 | Close‑up on Lumina v3 with swirling data | "Is guiding them the right thing?" |
+| 6 | Montage of diverging outcomes | rising tension score |
+| 7 | Crossroad sign with narrator overlay | "Choose wisely and subscribe" |

--- a/media/video_05_crossroads/voiceovers/README.md
+++ b/media/video_05_crossroads/voiceovers/README.md
@@ -1,0 +1,1 @@
+Voice-over tracks for each scene. Recordings should match the script draft and follow the numbering in the storyboard.


### PR DESCRIPTION
## Summary
- add storyboard and script draft for Video 5
- include voiceovers/assets/renders directories for Video 5 media
- update roadmap table with Video 05 row

## Testing
- `pre-commit` *(fails: `.pre-commit-config.yaml` missing)*
- `git push` *(fails: repository not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850e02b1f68832dbf109116ead78ab6