### PR TITLE
Add OmniIntent macro recorder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,5 @@ PY
           isort --check src tests
       - name: Run tests
         run: pytest -v tests
+      - name: Run macro recorder tests
+        run: pytest tests/test_macro_recorder.py

--- a/README.md
+++ b/README.md
@@ -30,3 +30,19 @@ Large media assets are stored using Git LFS to keep the repository lightweight.
 | Sprint-08 | Build BestWay scaffold and ingestion CLI | Video 01 storyboard |
 | Sprint-09 | Expand recipe collection | Video 02 storyboard |
 | Sprint-12 | Crossroads warning narrative | Video 05 storyboard |
+
+## Macro Recorder
+
+The `omniintent` package includes a simple macro recorder to capture demo sessions.
+
+Record a session using the transformer demo:
+
+```bash
+python -m omniintent.multimodal_transformer demo --record --macro-path macros/demo.json
+```
+
+Convert the recorded macro to Markdown and a timeline plot:
+
+```bash
+python tools/macro_to_markdown.py macros/demo.json --markdown-out demo.md --png-out demo.png
+```

--- a/src/omniintent/macro_recorder.py
+++ b/src/omniintent/macro_recorder.py
@@ -1,0 +1,59 @@
+import json
+import time
+from pathlib import Path
+from typing import Any, Dict, List
+
+_events: List[Dict[str, Any]] = []
+_recording = False
+
+
+def start_record() -> None:
+    """Begin recording macro events."""
+    global _events, _recording
+    _events = []
+    _recording = True
+    _events.append({"type": "start", "time": time.time()})
+
+
+def stop_record() -> None:
+    """Stop recording events."""
+    global _recording
+    if _recording:
+        _events.append({"type": "stop", "time": time.time()})
+        _recording = False
+
+
+def log_event(prompt: str, response: str) -> None:
+    """Record a prompt/response pair."""
+    if _recording:
+        _events.append(
+            {
+                "type": "step",
+                "time": time.time(),
+                "prompt": prompt,
+                "response": response,
+            }
+        )
+
+
+def save_json(path: Path) -> None:
+    """Write recorded events to a JSON file."""
+    if _events:
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", encoding="utf-8") as f:
+            json.dump(_events, f, indent=2)
+
+
+def replay(json_path: Path) -> None:
+    """Replay events from a saved macro."""
+    events = json.loads(Path(json_path).read_text())
+    prev_time = None
+    for event in events:
+        if prev_time is not None:
+            delay = event["time"] - prev_time
+            time.sleep(min(max(delay, 0), 2))
+        if event["type"] == "step":
+            print(event["prompt"])
+            print(event["response"])
+        prev_time = event["time"]

--- a/src/omniintent/multimodal_transformer.py
+++ b/src/omniintent/multimodal_transformer.py
@@ -1,4 +1,12 @@
-"""Placeholder transformer implementation."""
+"""Placeholder transformer implementation with demo loop."""
+
+import pathlib
+
+import typer
+
+from .macro_recorder import log_event, save_json, start_record, stop_record
+
+app = typer.Typer(add_completion=False)
 
 
 class MultimodalTransformer:
@@ -9,3 +17,33 @@ class MultimodalTransformer:
 
     def forward(self, *inputs):
         raise NotImplementedError("Model forward pass not implemented")
+
+
+@app.command()
+def demo(
+    record: bool = typer.Option(False, help="Record interaction"),
+    macro_path: pathlib.Path = typer.Option(
+        pathlib.Path("macros/demo.json"), help="Output macro JSON"
+    ),
+):
+    """Simple interactive demo for the transformer."""
+    model = MultimodalTransformer()
+    if record:
+        start_record()
+    typer.echo("Type 'quit' to exit.")
+    while True:
+        prompt = input(">>> ")
+        if prompt.lower() in {"quit", "exit"}:
+            break
+        response = f"Echo: {prompt}"
+        print(response)
+        if record:
+            log_event(prompt, response)
+    if record:
+        stop_record()
+        save_json(macro_path)
+        typer.echo(f"Saved macro to {macro_path}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app()

--- a/tests/test_macro_recorder.py
+++ b/tests/test_macro_recorder.py
@@ -1,0 +1,15 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+from omniintent import macro_recorder as mr
+
+
+def test_start_stop(tmp_path):
+    mr.start_record()
+    mr.log_event("hello", "world")
+    mr.stop_record()
+    out = tmp_path / "macro.json"
+    mr.save_json(out)
+    assert out.exists()
+    mr.replay(out)

--- a/tools/macro_to_markdown.py
+++ b/tools/macro_to_markdown.py
@@ -1,0 +1,49 @@
+"""Convert a macro JSON file to markdown summary and timeline plot."""
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import typer
+
+app = typer.Typer(add_completion=False)
+
+
+@app.command()
+def convert(
+    macro: Path,
+    markdown_out: Path = typer.Option(Path("macro_summary.md")),
+    png_out: Path = typer.Option(Path("macro_timeline.png")),
+):
+    """Generate markdown summary and a timeline image."""
+    events: List[Dict[str, Any]] = json.loads(macro.read_text())
+    steps = [e for e in events if e.get("type") == "step"]
+    if not steps:
+        typer.echo("No steps found in macro")
+        return
+    t0 = steps[0]["time"]
+    for s in steps:
+        s["elapsed"] = s["time"] - t0
+    df = pd.DataFrame(steps)
+    md_lines = [
+        "| step | prompt | response | elapsed (s) |",
+        "|------|--------|----------|-------------|",
+    ]
+    for i, row in df.iterrows():
+        md_lines.append(
+            f"| {i+1} | {row['prompt']} | {row['response']} | {row['elapsed']:.2f} |"
+        )
+    markdown_out.write_text("\n".join(md_lines), encoding="utf-8")
+    plt.figure()
+    plt.plot(df.index + 1, df["elapsed"], marker="o")
+    plt.xlabel("Step")
+    plt.ylabel("Elapsed (s)")
+    plt.tight_layout()
+    plt.savefig(png_out)
+    typer.echo(f"Wrote {markdown_out} and {png_out}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app()


### PR DESCRIPTION
## Summary
- implement `macro_recorder` module with basic record, save and replay helpers
- update `multimodal_transformer` with interactive demo and optional recording
- add utility `macro_to_markdown.py` for turning macros into Markdown tables and timeline plots
- document macro recorder usage
- include empty `macros/` directory
- extend CI workflow to run new macro recorder test
- create simple pytest for macro recorder

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685193d8e63c832d96e241ab9ef90aee