### PR TITLE
Add MkDocs site with GitHub Pages workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,21 @@
+name: docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'mkdocs.yml'
+      - 'docs/**'
+      - 'README.md'
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install -r requirements.txt
+      - run: mkdocs gh-deploy --force

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ tests/                unit & E2E suites (pytest + Playwright)
 | 10-11 | BeatBound SDK + Talk-Box therapy journeys | Video 03-04 |
 | 12 | **Video 05 – Crossroads Warning** | Public launch day |
 
+[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://tylerhk.github.io/LuminaNotes)
+
 **Governance & Safety**
 * [Governance Charter](docs/governance_charter.md) — proposal flow & voting
 * [Security Policy](SECURITY.md) — how to report vulnerabilities

--- a/docs/beatbound_overview.md
+++ b/docs/beatbound_overview.md
@@ -1,0 +1,3 @@
+# Beatbound Overview
+
+*Placeholder \u2014 link to relevant README sections or diagrams.*

--- a/docs/bestway_overview.md
+++ b/docs/bestway_overview.md
@@ -1,0 +1,3 @@
+# Bestway Overview
+
+*Placeholder \u2014 link to relevant README sections or diagrams.*

--- a/docs/echoes_overview.md
+++ b/docs/echoes_overview.md
@@ -1,0 +1,3 @@
+# Echoes Overview
+
+*Placeholder \u2014 link to relevant README sections or diagrams.*

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,8 @@
+# 👋\u00a0Welcome to **LuminaNotes**
+
+A public R&D notebook where **Tyler\u00a0H.** and **Lumina** co‑create tools, art,
+and research aimed at reducing human suffering and expanding creative agency.
+
+* Browse live demos \u27e9 *BeatBound*, *OmniIntent sandbox*  
+* Read the [Governance Charter](governance_charter.md) and [Security\u00a0Policy](../SECURITY.md)  
+* Contribute a BestWay recipe or plugin via pull‑request!

--- a/docs/omniintent_overview.md
+++ b/docs/omniintent_overview.md
@@ -1,0 +1,3 @@
+# Omniintent Overview
+
+*Placeholder \u2014 link to relevant README sections or diagrams.*

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,3 +1,23 @@
 site_name: LuminaNotes
-docs_dir: docs
-site_dir: site
+repo_url: https://github.com/TylerHK/LuminaNotes
+nav:
+  - Home: index.md
+  - Projects:
+      - Echoes: docs/echoes_overview.md
+      - OmniIntent: docs/omniintent_overview.md
+      - BestWay: docs/bestway_overview.md
+      - BeatBound: docs/beatbound_overview.md
+  - Governance: docs/governance_charter.md
+  - Security: SECURITY.md
+  - Manifest Log: docs/manifest_changelog.md
+markdown_extensions:
+  - admonition
+  - toc:
+      permalink: true
+theme:
+  name: material
+  palette:
+    scheme: slate
+  features:
+    - navigation.expand
+    - navigation.instant

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ matplotlib
 typer
 pyyaml
 
+mkdocs-material>=9.5


### PR DESCRIPTION
## Summary
- set up MkDocs configuration and site content
- add GitHub Pages deploy workflow
- include docs badge in README
- add mkdocs-material dependency

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`
- `git push --set-upstream origin docs/mkdocs-site` *(fails: `fatal: 'origin' does not appear to be a git repository`)*

------
https://chatgpt.com/codex/tasks/task_e_6853c9ccf648832d8446e42e66420f19