### PR TITLE
Add LFS guardrails

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+large=$(git diff --cached --name-only | xargs -I{} bash -c '[[ -f "{}" ]] && [[ $(stat -c%s "{}") -gt 5242880 ]] && echo "{}"')
+if [[ ! -z "$large" ]]; then
+  echo "❌  The following files exceed 5\u2009MB and are not LFS-tracked:"
+  echo "$large"
+  echo "Add them via: git lfs track <pattern> && git add .gitattributes <files>"
+  exit 1
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,13 @@ jobs:
         run: |
           pip install -r requirements.txt
           pip install black isort codespell
+      - name: Check for large non-LFS files
+        run: |
+          git ls-files | while read f; do
+            if [[ $(stat -c%s "$f") -gt 5242880 && $(git check-attr --all -- "$f" | grep -c "filter: lfs") -eq 0 ]]; then
+              echo "::error file=$f::File >5\u2009MB not LFS-tracked"; exit 1
+            fi
+          done
       - name: spell-check docs
         run: |
           pip install codespell

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 | **Policy Sims** – UBI, climate, etc. | `notebooks/`, `src/policy_sim/` | Transparent economic and social-impact models. |
 
 Large media or binary assets are stored via **Git LFS**.
+A pre-commit hook and CI check block any file >5\u2009MB that is not LFS-tracked.
 
 ---
 


### PR DESCRIPTION
## Summary
- add pre-commit hook for blocking large non-LFS files
- enforce the same check in CI
- document Git LFS guardrail in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853cbe7db2c832db278af7d65537154