### PR TITLE
Add SwarmSync helper and indexing workflow

### DIFF
--- a/.github/workflows/swarm-index.yml
+++ b/.github/workflows/swarm-index.yml
@@ -1,0 +1,29 @@
+name: swarm-index
+on:
+  schedule:
+    - cron: '15 * * * *'    # hourly
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: build index
+        run: |
+          python - <<'PY'
+          import json, glob, pathlib
+          packets = []
+          for p in glob.glob('swarm_sync/*.json'):
+              packets.append(json.load(open(p)))
+          # simple index {keyword: [timestamps]}
+          index={}
+          for pkt in packets:
+              index.setdefault(pkt['keyword'],[]).append(pkt['timestamp'])
+          pathlib.Path('swarm_sync/swarm_index.json').write_text(json.dumps(index,indent=2))
+          PY
+      - name: commit
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore: update swarm index"
+          file_pattern: swarm_sync/swarm_index.json

--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ npm i && npm run dev   # then open localhost:5173
 python bestway/CLI/ingest.py recipes/solar_dehydrator.md
 ```
 
+### SwarmSync (cross‑chat memory)
+
+`!sync-to hive <keyword>` → posts the last\u00A0N messages to GitHub.  
+`?hive <keyword>`        → pulls summaries from other chats.
+
 ---
 
 ## Contributing & Governance

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ typer
 pyyaml
 
 mkdocs-material>=9.5
+PyGithub>=2.3

--- a/tools/swarm_sync.py
+++ b/tools/swarm_sync.py
@@ -1,0 +1,44 @@
+"""
+swarm_sync.py
+-------------
+CLI to post or fetch "sync packets" to GitHub.
+Run from any environment where GITHUB_TOKEN is set.
+"""
+import os, json, datetime, pathlib, sys
+from github import Github
+
+REPO = "TylerHK/LuminaNotes"
+FOLDER = "swarm_sync"
+
+def post(keyword:str, summary:str, raw:str, source:str):
+    gh = Github(os.environ["GITHUB_TOKEN"])
+    repo = gh.get_repo(REPO)
+    day = datetime.datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    fname = f"{FOLDER}/{day}_{source}_{keyword}.json"
+    body = json.dumps({
+        "keyword": keyword,
+        "timestamp": day,
+        "summary": summary,
+        "raw": raw,
+        "source_chat": source
+    }, indent=2)
+    repo.create_file(fname, f"swarm: add {keyword} from {source}", body, branch="main")
+
+def fetch(keyword:str, limit:int=5):
+    gh = Github(os.environ["GITHUB_TOKEN"])
+    repo = gh.get_repo(REPO)
+    contents = repo.get_contents(FOLDER)
+    hits=[]
+    for c in contents:
+        if keyword in c.name:
+            hits.append(json.loads(repo.get_contents(c.path).decoded_content))
+    # newest first
+    hits = sorted(hits, key=lambda x: x["timestamp"], reverse=True)[:limit]
+    print(json.dumps(hits, indent=2))
+
+if __name__ == "__main__":
+    cmd,*args = sys.argv[1:]
+    if cmd=="post":
+        post(*args)   # keyword summary raw source_chat
+    elif cmd=="fetch":
+        fetch(args[0])


### PR DESCRIPTION
## Summary
- add PyGithub dependency for GitHub API usage
- implement `tools/swarm_sync.py` helper
- index sync packets with new GitHub Action
- document SwarmSync usage in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862e6b20e70832dbfa2c6ef701cccea