### PR TITLE
Add SwarmSync helper script and PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/swarm_sync.md
+++ b/.github/PULL_REQUEST_TEMPLATE/swarm_sync.md
@@ -1,0 +1,15 @@
+### 📥  SwarmSync Packet
+
+| Keyword | Source Chat | Timestamp (UTC) |
+|---------|-------------|-----------------|
+| <!-- filled by author --> | | |
+
+#### Summary  
+> _Paste the `summary` field here._
+
+---
+
+- [ ] I confirm the packet contains no sensitive personal data.  
+- [ ] Keyword is spelled consistently with existing packets.  
+- [ ] I ran `scripts/sync_helper.py` to generate the JSON file.  
+

--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ python bestway/CLI/ingest.py recipes/solar_dehydrator.md
 `!sync-to hive <keyword>` → posts the last\u00A0N messages to GitHub.  
 `?hive <keyword>`        → pulls summaries from other chats.
 
+```bash
+# helper from any terminal
+python scripts/sync_helper.py path/to/chat.log omniintent myChatGPT
+```
+
 ---
 
 ## Contributing & Governance

--- a/scripts/sync_helper.py
+++ b/scripts/sync_helper.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+"""
+sync_helper.py
+--------------
+Usage:
+  python scripts/sync_helper.py <chat_log.txt> <keyword> <source>
+
+Reads the last 20 lines of the chat log, generates a naive
+summary (first + last line fallback), and posts via SwarmSync.
+"""
+import sys, os, pathlib, tools.swarm_sync as hive
+
+log, keyword, source = sys.argv[1:4]
+lines = pathlib.Path(log).read_text().splitlines()[-20:]
+summary = lines[0][:120] + " … " + lines[-1][:120]
+raw = "\n".join(lines)
+
+hive.post(keyword, summary, raw, source)
+print("🪽  Synced", keyword, "from", source)


### PR DESCRIPTION
## Summary
- add script to sync chat logs via SwarmSync
- document helper usage in README
- include SwarmSync packet PR template

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686300e08e24832d97bccfd29e2a1cf6